### PR TITLE
Release

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1868,19 +1868,19 @@ void Adafruit_NeoPixel::show(void) {
         // data ONE high
         // min: 550 typ: 700 max: 5,500
         gpio_set(pin);
-        delay_ns(600);
+        delay_ns(700);
         // min: 450 typ: 600 max: 5,000
         gpio_clear(pin);
-        delay_ns(500);
+        delay_ns(600);
       } else {
         // data ZERO high
         // min: 200  typ: 350 max: 500
         gpio_set(pin);
-        delay_ns(250);
+        delay_ns(350);
         // data low
         // min: 450 typ: 600 max: 5,000
         gpio_clear(pin);
-        delay_ns(500);
+        delay_ns(600);
       }
       if(bitMask >>= 1) {
         // Move on to the next pixel

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit NeoPixel
-version=1.3.0
+version=1.3.0.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for controlling single-wire-based LED pixels and strip.


### PR DESCRIPTION
Changed the default delay times for TARGET_LPC1768. Used the typical delay times, instead the min values. The min delay times are not working property. Tested on SKR 1.4, which has the LPC1769 cpu. 